### PR TITLE
fix changeOnSelect can't work when expandTrigger='hover'

### DIFF
--- a/src/Cascader.jsx
+++ b/src/Cascader.jsx
@@ -121,7 +121,7 @@ class Cascader extends Component {
     if (triggerNode && triggerNode.focus) {
       triggerNode.focus();
     }
-    const { changeOnSelect, loadData } = this.props;
+    const { changeOnSelect, loadData, expandTrigger } = this.props;
     if (!targetOption || targetOption.disabled) {
       return;
     }
@@ -142,8 +142,13 @@ class Cascader extends Component {
       this.handleChange(activeOptions, { visible: false }, e);
       // set value to activeValue when select leaf option
       newState.value = activeValue;
-    } else if (changeOnSelect) {
-      this.handleChange(activeOptions, { visible: true }, e);
+      // add e.type judgement to prevent `onChange` being triggered by mouseEnter
+    } else if (changeOnSelect && (e.type === 'click' || e.type === 'keydown')) {
+      if (expandTrigger === 'hover') {
+        this.handleChange(activeOptions, { visible: false }, e);
+      } else {
+        this.handleChange(activeOptions, { visible: true }, e);
+      }
       // set value to activeValue on every select
       newState.value = activeValue;
     }
@@ -274,6 +279,7 @@ Cascader.defaultProps = {
   popupClassName: '',
   popupPlacement: 'bottomLeft',
   builtinPlacements: BUILT_IN_PLACEMENTS,
+  expandTrigger: 'click',
 };
 
 Cascader.propTypes = {
@@ -294,6 +300,7 @@ Cascader.propTypes = {
   changeOnSelect: PropTypes.bool,
   children: PropTypes.node,
   onKeyDown: PropTypes.func,
+  expandTrigger: PropTypes.string,
 };
 
 export default Cascader;

--- a/src/Menus.jsx
+++ b/src/Menus.jsx
@@ -29,6 +29,7 @@ class Menus extends React.Component {
       expandProps = {
         onMouseEnter: this.delayOnSelect.bind(this, onSelect),
         onMouseLeave: this.delayOnSelect.bind(this),
+        onClick: onSelect,
       };
     }
     if (this.isActiveOption(option, menuIndex)) {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -362,4 +362,41 @@ describe('Cascader', () => {
       done();
     }, 100);
   });
+
+  // https://github.com/ant-design/ant-design/issues/7480
+  it('should call onChange on click when expandTrigger=hover with changeOnSelect', (done) => {
+    instance = ReactDOM.render(
+      <Cascader changeOnSelect expandTrigger="hover" options={addressOptions} onChange={onChange}>
+        <input readOnly />
+      </Cascader>
+    , div);
+
+    Simulate.click(ReactDOM.findDOMNode(instance));
+    const menus = instance.getPopupDOMNode().querySelectorAll('.rc-cascader-menu');
+    expect(menus.length).to.be(1);
+    const menu1Items = menus[0].querySelectorAll('.rc-cascader-menu-item');
+    expect(menu1Items.length).to.be(3);
+    Simulate.click(menu1Items[0]);
+    expect(selectedValue[0]).to.be('fj');
+    expect(instance.state.popupVisible).not.to.be.ok();
+    done();
+  });
+
+  it('should not call onChange on hover when expandTrigger=hover with changeOnSelect', (done) => {
+    instance = ReactDOM.render(
+      <Cascader changeOnSelect expandTrigger="hover" options={addressOptions} onChange={onChange}>
+        <input readOnly />
+      </Cascader>
+    , div);
+
+    Simulate.click(ReactDOM.findDOMNode(instance));
+    const menus = instance.getPopupDOMNode().querySelectorAll('.rc-cascader-menu');
+    expect(menus.length).to.be(1);
+    const menu1Items = menus[0].querySelectorAll('.rc-cascader-menu-item');
+    expect(menu1Items.length).to.be(3);
+    Simulate.mouseEnter(menu1Items[0]);
+    expect(selectedValue).not.to.be.ok();
+    expect(instance.state.popupVisible).to.be.ok();
+    done();
+  });
 });


### PR DESCRIPTION
- fix `changeOnSelect` can't work when `expandTrigger='hover'`
- mouseEnter should not trigger value changing(when `expandTrigger='hover'`)

https://github.com/ant-design/ant-design/issues/7480