### PR TITLE
1.修复级联菜单children没有数据的时候 依旧显示空白栏的问题

### DIFF
--- a/src/Menus.jsx
+++ b/src/Menus.jsx
@@ -97,7 +97,9 @@ class Menus extends React.Component {
     const { options } = this.props;
     const result = this.getActiveOptions()
       .map(activeOption => activeOption[this.getFieldName('children')])
-      .filter(activeOption => !!activeOption);
+      .filter(activeOption => {
+        return !!activeOption && Array.isArray(activeOption) && activeOption.length > 0;
+      });
     result.unshift(options);
     return result;
   }
@@ -173,6 +175,7 @@ Menus.propTypes = {
   fieldNames: PropTypes.object,
   expandIcon: PropTypes.node,
   loadingIcon: PropTypes.node,
+  onItemDoubleClick: PropTypes.func,
 };
 
 export default Menus;


### PR DESCRIPTION
a -> b ->c []
c的children是一个空数组
a - b 选中以后 
当你下次再打开的时候 会把空的c也直接回显出来 这个感觉不合理
