### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "jest": "^26.0.0",
     "np": "^6.0.0",
     "rc-form": "^2.4.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "jest": "^26.0.0",
     "np": "^6.0.0",
     "rc-form": "^2.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "typescript": "^3.5.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "rc-trigger": "^5.0.4",
     "rc-util": "^5.0.1",
     "warning": "^4.0.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
