### PR TITLE
fix: Call passed onKeyDown in all cases when handling keydown event

### DIFF
--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -290,6 +290,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
       e.keyCode !== KeyCode.TAB
     ) {
       this.setPopupVisible(true);
+      if (this.props.onKeyDown) {
+        this.props.onKeyDown(e);
+      }
       return;
     }
     if (e.keyCode === KeyCode.DOWN || e.keyCode === KeyCode.UP) {
@@ -324,6 +327,9 @@ class Cascader extends React.Component<CascaderProps, CascaderState> {
       }
     } else if (e.keyCode === KeyCode.ESC || e.keyCode === KeyCode.TAB) {
       this.setPopupVisible(false);
+      if (this.props.onKeyDown) {
+        this.props.onKeyDown(e);
+      }
       return;
     }
     if (!activeValue || activeValue.length === 0) {

--- a/tests/keyboard.spec.js
+++ b/tests/keyboard.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import KeyCode from 'rc-util/lib/KeyCode';
-import Cascader from '../';
+import Cascader from '..';
 import { addressOptions } from './demoOptions';
 
 describe('Cascader', () => {
@@ -129,6 +129,23 @@ describe('Cascader', () => {
         .hostNodes()
         .hasClass('rc-cascader-menus-hidden'),
     ).toBe(true);
+  });
+
+  it('should call the Cascader onKeyDown callback in all cases', () => {
+    const onKeyDown = jest.fn();
+
+    wrapper = mount(
+      <Cascader options={addressOptions} onChange={onChange} onKeyDown={onKeyDown} expandIcon="">
+        <input readOnly />
+      </Cascader>,
+    );
+    wrapper.find('input').simulate('keyDown', { keyCode: KeyCode.DOWN });
+    expect(wrapper.state().popupVisible).toBeTruthy();
+    wrapper.find('input').simulate('keyDown', { keyCode: KeyCode.ESC });
+    expect(wrapper.state().popupVisible).toBeFalsy();
+    wrapper.find('input').simulate('keyDown', { keyCode: KeyCode.ENTER });
+
+    expect(onKeyDown).toHaveBeenCalledTimes(3);
   });
 
   it('should not handle keyDown events when children specify the onKeyDown', () => {


### PR DESCRIPTION
This allows the caller to also handle the keys that returned early (eg. Escape) and stopPropagation on them, for example.