### PR TITLE
Use ReactNode for children of Cascader to allow null, strings and more

### DIFF
--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -71,7 +71,7 @@ interface BaseCascaderProps
     | 'onChange'
   > {
   options?: DataNode[];
-  children?: React.ReactElement;
+  children?: React.ReactNode;
 
   // Value
   value?: CascaderValueType | CascaderValueType[];


### PR DESCRIPTION
This is the default behaviour for components in React, and will allow `null` as a child (which is the result when typing `<Component />`).