### PR TITLE
fix: allow override value field name / 修复自定义value的FieldName时报错

### DIFF
--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -206,13 +206,14 @@ const Cascader = React.forwardRef((props: CascaderProps, ref: React.Ref<Cascader
 
   // ========================== Options ===========================
   const outerFieldNames = React.useMemo(() => fillFieldNames(fieldNames), [fieldNames]);
-  const mergedFieldNames = React.useMemo(
-    () => ({
-      ...outerFieldNames,
-      value: INTERNAL_VALUE_FIELD,
-    }),
-    [outerFieldNames],
-  );
+  const mergedFieldNames = React.useMemo(() => {
+    const { label: fieldLabel, value: fieldValue } = outerFieldNames;
+    // if label and value field name are equal, we add a unique **INTERNAL_VALUE_FIELD** field to represent the value
+    // otherwise, we still use the original fieldNames to allow override **value** field
+    return fieldLabel === fieldValue
+      ? { ...outerFieldNames, value: INTERNAL_VALUE_FIELD }
+      : outerFieldNames;
+  }, [outerFieldNames]);
 
   const mergedOptions = React.useMemo(() => {
     return convertOptions(options, outerFieldNames, INTERNAL_VALUE_FIELD);

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,7 +30,7 @@ export function restoreCompatibleValue(
 
   while (current) {
     path.unshift(current.data.node[fieldNames.value]);
-    options.unshift(current.data.node as any as InternalDataNode);
+    options.unshift((current.data.node as any) as InternalDataNode);
 
     current = current.parent;
   }
@@ -70,7 +70,7 @@ export function splitValue(str: string) {
  */
 export function convertOptions(
   options: DataNode[],
-  { value: fieldValue, children: fieldChildren }: FieldNames,
+  { label: fieldLabel, value: fieldValue, children: fieldChildren }: FieldNames,
   internalValueField: string,
 ): InternalDataNode[] {
   function injectValue(list: DataNode[], parentValue = ''): InternalDataNode[] {
@@ -85,7 +85,8 @@ export function convertOptions(
 
       const cloneOption = {
         ...option,
-        [internalValueField]: newValue,
+        // if fieldLabel === fieldValue, use internalValueField to store the value instead
+        [fieldLabel === fieldValue ? internalValueField : fieldValue]: newValue,
         node: option,
       };
 

--- a/tests/fieldNames.spec.tsx
+++ b/tests/fieldNames.spec.tsx
@@ -119,4 +119,40 @@ describe('Cascader.FieldNames', () => {
 
     expect(wrapper.find('.rc-cascader-menu-item').last().text()).toEqual('little');
   });
+
+  it('should be no warning when use key field as value', () => {
+    const option = [
+      {
+        title: '福建',
+        key: 'fj',
+        children: [
+          {
+            title: '福州',
+            key: 'fuzhou',
+            children: [
+              {
+                title: '马尾',
+                key: 'mawei',
+              },
+            ],
+          },
+        ],
+      },
+    ] as any;
+    let warning = false;
+    jest.spyOn(console, 'error').mockImplementation(() => {
+      warning = true;
+    });
+    mount(
+      <Cascader
+        options={option}
+        fieldNames={{
+          label: 'title',
+          value: 'key',
+        }}
+      />,
+    );
+
+    expect(warning).toBe(false);
+  });
 });


### PR DESCRIPTION
when setting fieldNames `value` to custom field name like `key` , current version of `Cascader` will throw a warning :
在cascader中使用fieldName指定value为 'key'时, 会出现以下错误：

![image](https://user-images.githubusercontent.com/45778220/146116320-76117425-68c9-40a4-93d6-94b6b3a0a3ea.png)

reproduce link:

[CodeSandBox](https://codesandbox.io/s/fieldnames-antd-4-17-3-7mhld?file=/index.js)


| Item    |  Version |
| ------ | ----- |
| React | 17.0 |
| Antd | 4.17.2 | 