### PR TITLE
fix: Trade empty children option as leaf node

### DIFF
--- a/examples/debug.tsx
+++ b/examples/debug.tsx
@@ -5,6 +5,11 @@ import Cascader from '../src';
 
 const addressOptions = [
   {
+    label: '空孩子',
+    value: 'empty',
+    children: [],
+  },
+  {
     label: '福建',
     value: 'fj',
     title: '测试标题',
@@ -86,7 +91,7 @@ const addressOptions = [
 const defaultValue = ['not', 'exist'];
 
 const Demo = () => {
-  const [multiple, setMultiple] = React.useState(true);
+  const [multiple, setMultiple] = React.useState(false);
   const [, setInputValue] = React.useState('');
 
   const onChange = (value: any, selectedOptions: any) => {
@@ -109,7 +114,7 @@ const Demo = () => {
       </label>
       <Cascader
         style={{ width: 200 }}
-        // options={addressOptions}
+        options={addressOptions}
         onChange={onChange}
         checkable={multiple}
         allowClear

--- a/src/OptionList/index.tsx
+++ b/src/OptionList/index.tsx
@@ -123,7 +123,7 @@ const RefOptionList = React.forwardRef<RefOptionListProps>((props, ref) => {
       );
 
       const subOptions = currentOption?.[fieldNames.children];
-      if (!subOptions) {
+      if (!subOptions?.length) {
         break;
       }
 

--- a/src/utils/commonUtil.ts
+++ b/src/utils/commonUtil.ts
@@ -31,5 +31,5 @@ export function fillFieldNames(fieldNames?: FieldNames): InternalFieldNames {
 }
 
 export function isLeaf(option: DefaultOptionType, fieldNames: FieldNames) {
-  return option.isLeaf ?? !option[fieldNames.children];
+  return option.isLeaf ?? !option[fieldNames.children]?.length;
 }

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -687,4 +687,27 @@ describe('Cascader.Basic', () => {
     expect(onValueChange).toHaveBeenCalledWith([1], expect.anything());
     expect(wrapper.find('.rc-cascader-selection-item').text()).toEqual('One');
   });
+
+  it('empty children is last children', () => {
+    const onValueChange = jest.fn();
+
+    const wrapper = mount(
+      <Cascader
+        open
+        onChange={onValueChange}
+        options={[
+          {
+            label: 'parent',
+            value: 'parent',
+            children: [],
+          },
+        ]}
+      />,
+    );
+
+    wrapper.clickOption(0, 0);
+
+    expect(onValueChange).toHaveBeenCalledWith(['parent'], expect.anything());
+    expect(wrapper.find('ul.rc-cascader-menu')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
原本  children 为 空数组时，上游可以选择是个 bug。但是似乎 bug as feature 特别多。干脆 children 是空数组也当成 leaf 来处理保持一致性。