### PR TITLE
export SignleCascaderProps and MultipleCascaderProps to index file

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,5 +6,7 @@ export type {
   ShowSearchType,
   DefaultOptionType,
   BaseOptionType,
+  SingleCascaderProps,
+  MultipleCascaderProps,
 } from './Cascader';
 export default Cascader;


### PR DESCRIPTION
#220 忘了在index文件中导出SignleCascaderProps和MultipleCascaderProps了。这边补上。ant-design的[相关pr](https://github.com/ant-design/ant-design/pull/33947)