### PR TITLE
fix(清空选项时动态修改options): 导致children获取不到，undefined报错

### DIFF
--- a/src/OptionList/useKeyboard.ts
+++ b/src/OptionList/useKeyboard.ts
@@ -26,7 +26,7 @@ export default (
     const len = activeValueCells.length;
 
     // Fill validate active value cells and index
-    for (let i = 0; i < len; i += 1) {
+    for (let i = 0; i < len && currentOptions; i += 1) {
       // Mark the active index for current options
       const nextActiveIndex = currentOptions.findIndex(
         option => option[fieldNames.value] === activeValueCells[i],


### PR DESCRIPTION
Cascader loadData 选择到第三级，点击清空按钮，在清空回调，设置只有一级的options 会崩溃报错 #34563
https://github.com/ant-design/ant-design/issues/34563