### PR TITLE
children获取不到，undefined报错

### DIFF
--- a/src/OptionList/useKeyboard.ts
+++ b/src/OptionList/useKeyboard.ts
@@ -26,7 +26,7 @@ export default (
     const len = activeValueCells.length;
 
     // Fill validate active value cells and index
-    for (let i = 0; i < len; i += 1) {
+    for (let i = 0; i < len && currentOptions; i += 1) {
       // Mark the active index for current options
       const nextActiveIndex = currentOptions.findIndex(
         option => option[fieldNames.value] === activeValueCells[i],

--- a/tests/loadData.spec.tsx
+++ b/tests/loadData.spec.tsx
@@ -182,4 +182,57 @@ describe('Cascader.LoadData', () => {
 
     expect(wrapper.find('ul.rc-cascader-menu')).toHaveLength(3);
   });
+  it('when selected modify options', async () => {
+    const Demo = ({ updateNum = 0 }) => {
+      const [options, setOptions] = React.useState([{ label: 'top', value: 'top', isLeaf: false }]);
+      const [value, setValue] = React.useState([]);
+
+      React.useEffect(() => {
+        if (updateNum > 0) {
+          setValue([]);
+          setOptions([{ label: 'top', value: 'top', isLeaf: false }]);
+        }
+      }, [updateNum]);
+
+      const loadData = selectedOptions => {
+        Promise.resolve().then(() => {
+          act(() => {
+            selectedOptions[selectedOptions.length - 1].children = [
+              {
+                label: 'child',
+                value: 'child',
+                isLeaf: false,
+              },
+            ];
+            setOptions(list => [...list]);
+            setValue(['child']);
+          });
+        });
+      };
+
+      return <Cascader value={value} options={options} loadData={loadData} open />;
+    };
+
+    const wrapper = mount(<Demo />);
+
+    // First column click
+    wrapper.find('.rc-cascader-menu-item-content').last().simulate('click');
+    for (let i = 0; i < 3; i += 1) {
+      await Promise.resolve();
+    }
+    wrapper.update();
+
+    // Second column click
+    wrapper.find('.rc-cascader-menu-item-content').last().simulate('click');
+    for (let i = 0; i < 3; i += 1) {
+      await Promise.resolve();
+    }
+    wrapper.update();
+
+    wrapper.setProps({
+      updateNum: 1,
+    });
+
+    wrapper.update();
+  });
 });


### PR DESCRIPTION
Cascader loadData 选择到第三级，点击清空按钮，在清空回调，设置只有一级的options 会崩溃报错 #34563
https://github.com/ant-design/ant-design/issues/34563