### PR TITLE
fix:  BaseSelect uses `key` property of displayValues as `itemKey`

### DIFF
--- a/src/hooks/useDisplayValues.ts
+++ b/src/hooks/useDisplayValues.ts
@@ -51,7 +51,7 @@ export default (
 
       return {
         label,
-        value: toPathKey(valueCells),
+        key: toPathKey(valueCells),
         valueCells,
       };
     });

--- a/src/hooks/useDisplayValues.ts
+++ b/src/hooks/useDisplayValues.ts
@@ -49,9 +49,12 @@ export default (
         valueOptions.map(({ option }) => option),
       );
 
+      const value = toPathKey(valueCells);
+
       return {
         label,
-        key: toPathKey(valueCells),
+        value,
+        key: value,
         valueCells,
       };
     });

--- a/tests/selector.spec.tsx
+++ b/tests/selector.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { mount } from './enzyme';
 import Cascader from '../src';
 import { addressOptions } from './demoOptions';
@@ -32,6 +32,55 @@ describe('Cascader.Selector', () => {
 
     wrapper.find('.rc-cascader-selection-item-remove-icon').first().simulate('click');
     expect(onChange).toHaveBeenCalledWith([['exist']], expect.anything());
+  });
+
+  it('avoid reuse', () => {
+    const Tag: React.FC<any> = ({ children, onClose }) => {
+      const [visible, setVisible] = useState(true);
+      return (
+        <button
+          onClick={() => {
+            setVisible(false);
+            onClose();
+          }}
+          className={visible ? '' : 'reuse'}
+        >
+          {children}
+        </button>
+      );
+    };
+
+    const wrapper = mount(
+      <Cascader
+        options={[
+          { label: 'AA', value: 'aa' },
+          { label: 'BB', value: 'bb' },
+          { label: 'CC', value: 'cc' },
+          { label: 'DD', value: 'dd' },
+          { label: 'EE', value: 'ee' },
+        ]}
+        value={[['aa'], ['bb'], ['cc'], ['dd'], ['ee']]}
+        onChange={values => {
+          wrapper.setProps({
+            value: values,
+          });
+        }}
+        tagRender={({ label, onClose }) => (
+          <Tag onClose={onClose} id={label}>
+            {label}
+          </Tag>
+        )}
+        checkable
+      />,
+    );
+
+    for (let i = 5; i > 0; i--) {
+      const buttons = wrapper.find('button');
+      expect(buttons.length).toBe(i);
+      buttons.first().simulate('click');
+      wrapper.update();
+      expect(wrapper.find('.reuse').length).toBe(0);
+    }
   });
 
   it('when selected modify options', () => {


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/34631