### PR TITLE
fix(antd@4.x): Cascader should not clear search input when press left/right key

### DIFF
--- a/examples/adjust-overflow.tsx
+++ b/examples/adjust-overflow.tsx
@@ -121,7 +121,7 @@ const placements = {
 
 function Demo() {
   return (
-    <div style={{ position: 'absolute', right: 10, top: 150 }}>
+    <div>
       <MyCascader />
       <br />
       <br />

--- a/src/OptionList/useKeyboard.ts
+++ b/src/OptionList/useKeyboard.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
-import type { RefOptionListProps } from 'rc-select/lib/OptionList';
 import { useBaseProps } from 'rc-select';
+import type { RefOptionListProps } from 'rc-select/lib/OptionList';
 import KeyCode from 'rc-util/lib/KeyCode';
+import * as React from 'react';
 import type { DefaultOptionType, InternalFieldNames, SingleValueType } from '../Cascader';
 import { SEARCH_MARK } from '../hooks/useSearchOptions';
 
@@ -125,6 +125,9 @@ export default (
         }
 
         case KeyCode.LEFT: {
+          if (searchValue) {
+            break;
+          }
           if (rtl) {
             nextColumn();
           } else {
@@ -134,6 +137,9 @@ export default (
         }
 
         case KeyCode.RIGHT: {
+          if (searchValue) {
+            break;
+          }
           if (rtl) {
             prevColumn();
           } else {

--- a/tests/keyboard.spec.tsx
+++ b/tests/keyboard.spec.tsx
@@ -227,6 +227,19 @@ describe('Cascader.Keyboard', () => {
     ).toHaveLength(0);
   });
 
+  it('should not switch column when press left/right key in search input', () => {
+    wrapper = mount(<Cascader options={addressOptions} showSearch />);
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '123',
+      },
+    });
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.LEFT });
+    expect(wrapper.isOpen()).toBeTruthy();
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.RIGHT });
+    expect(wrapper.isOpen()).toBeTruthy();
+  });
+
   // TODO: This is strange that we need check on this
   it.skip('should not handle keyDown events when children specify the onKeyDown', () => {
     wrapper = mount(


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/43401