### PR TITLE
fix(antd@5.x): Cascader should not clear search input when press left/right key

### DIFF
--- a/examples/adjust-overflow.tsx
+++ b/examples/adjust-overflow.tsx
@@ -121,7 +121,7 @@ const placements = {
 
 function Demo() {
   return (
-    <div style={{ position: 'absolute', right: 10, top: 150 }}>
+    <div>
       <MyCascader />
       <br />
       <br />

--- a/src/OptionList/useKeyboard.ts
+++ b/src/OptionList/useKeyboard.ts
@@ -135,6 +135,9 @@ export default (
         }
 
         case KeyCode.LEFT: {
+          if (searchValue) {
+            break;
+          }
           if (rtl) {
             nextColumn();
           } else {
@@ -144,6 +147,9 @@ export default (
         }
 
         case KeyCode.RIGHT: {
+          if (searchValue) {
+            break;
+          }
           if (rtl) {
             prevColumn();
           } else {

--- a/tests/keyboard.spec.tsx
+++ b/tests/keyboard.spec.tsx
@@ -245,6 +245,19 @@ describe('Cascader.Keyboard', () => {
     ).toHaveLength(0);
   });
 
+  it('should not switch column when press left/right key in search input', () => {
+    wrapper = mount(<Cascader options={addressOptions} showSearch />);
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: '123',
+      },
+    });
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.LEFT });
+    expect(wrapper.isOpen()).toBeTruthy();
+    wrapper.find('input').simulate('keyDown', { which: KeyCode.RIGHT });
+    expect(wrapper.isOpen()).toBeTruthy();
+  });
+
   // TODO: This is strange that we need check on this
   it.skip('should not handle keyDown events when children specify the onKeyDown', () => {
     wrapper = mount(


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/43401