### PR TITLE
fix(cascader): change cascader should go top

### DIFF
--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -173,7 +173,7 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
         `li[data-path-key="${cellKeyPath.replace(/\\{0,2}"/g, '\\"')}"]`, // matches unescaped double quotes
       );
       if (ele) {
-        scrollIntoParentView(ele);
+        scrollIntoParentView(ele, activeValueCells);
       }
     }
   }, [activeValueCells]);

--- a/src/utils/commonUtil.ts
+++ b/src/utils/commonUtil.ts
@@ -44,7 +44,7 @@ export function isLeaf(option: DefaultOptionType, fieldNames: FieldNames) {
   return option.isLeaf ?? !option[fieldNames.children]?.length;
 }
 
-export function scrollIntoParentView(element: HTMLElement) {
+export function scrollIntoParentView(element: HTMLElement, activeValueCells: React.Key[]) {
   const parent = element.parentElement;
   if (!parent) {
     return;
@@ -55,6 +55,13 @@ export function scrollIntoParentView(element: HTMLElement) {
     parent.scrollTo({ top: elementToParent });
   } else if (elementToParent + element.offsetHeight - parent.scrollTop > parent.offsetHeight) {
     parent.scrollTo({ top: elementToParent + element.offsetHeight - parent.offsetHeight });
+  } else {
+    const parentContainerSiblings = parent.parentElement.children;
+    if (!activeValueCells.length || activeValueCells.length === parentContainerSiblings.length) return
+    const container = parentContainerSiblings[activeValueCells.length];
+    if (container && typeof container.scrollTo === 'function') {
+      container.scrollTo({ top: 0 });
+    }
   }
 }
 


### PR DESCRIPTION
In certain cases, if the user switches the option of the cascader component, the page should return to the top of the component.This resolves https://github.com/ant-design/ant-design/issues/44382