### PR TITLE
fix: Cascader组件没有使用useActive-hook导致无法强关联,通过context解决

### DIFF
--- a/docs/demo/linkage.md
+++ b/docs/demo/linkage.md
@@ -1,0 +1,8 @@
+---
+title: linkage
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../../examples/linkage.tsx"></code>

--- a/examples/linkage.tsx
+++ b/examples/linkage.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import Cascader from '../src';
+
+export default function Linkage() {
+  const [selectData, setSelectData] = useState([]);
+
+  const options = [{
+    label: '福建',
+    value: 'fj',
+    children: [{
+      label: '宁德',
+      value: 'ningde'
+    }]
+  }, {
+    label: '杭州',
+    value: 'hangzhou'
+  }, {
+    label: '上海',
+    value: 'shanghai'
+  }];
+ 
+  const onChange = (val) => {
+    setSelectData(val)
+  }
+  return (
+    <div className="App">
+      <Cascader
+        showSearch
+        autoFocus
+        value={selectData}
+        dropdownMatchSelectWidth
+        style={{
+          width: '100%',
+          marginBottom: 20,
+        }}
+        options={options}
+        onChange={onChange}
+        placeholder="产品类目搜索"
+      />
+      <Cascader.Panel
+        value={selectData}
+        style={{
+          width: '100%'
+        }}
+        options={options}
+        onChange={onChange}
+      />
+    </div>
+  );
+}

--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -207,7 +207,7 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
 
   const columnNodes: React.ReactElement[] = mergedOptionColumns.map((col, index) => {
     const prevValuePath = activeValueCells.slice(0, index);
-    const activeValue = activeValueCells[index] ? activeValueCells[index] : values[0]?.[index];
+    const activeValue = values[0]?.[index] ?? activeValueCells[index];
 
     return (
       <Column

--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -207,7 +207,7 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
 
   const columnNodes: React.ReactElement[] = mergedOptionColumns.map((col, index) => {
     const prevValuePath = activeValueCells.slice(0, index);
-    const activeValue = activeValueCells[index];
+    const activeValue = activeValueCells[index] ? activeValueCells[index] : values[0]?.[index];
 
     return (
       <Column


### PR DESCRIPTION
在某些场景下，想使用两个Cascader组件进行强关联时，无法实现数据共通，因为在Cascader组件内部没有调用List组件中的useActive-hook，通过context来获取values，进行数据共享