### PR TITLE
fix: search no scroll

### DIFF
--- a/src/OptionList/Column.tsx
+++ b/src/OptionList/Column.tsx
@@ -23,7 +23,6 @@ export interface ColumnProps<OptionType extends DefaultOptionType = DefaultOptio
   halfCheckedSet: Set<React.Key>;
   loadingKeys: React.Key[];
   isSelectable: (option: DefaultOptionType) => boolean;
-  searchValue?: string;
 }
 
 export default function Column<OptionType extends DefaultOptionType = DefaultOptionType>({
@@ -39,7 +38,6 @@ export default function Column<OptionType extends DefaultOptionType = DefaultOpt
   halfCheckedSet,
   loadingKeys,
   isSelectable,
-  searchValue,
 }: ColumnProps<OptionType>) {
   const menuPrefixCls = `${prefixCls}-menu`;
   const menuItemPrefixCls = `${prefixCls}-menu-item`;
@@ -117,7 +115,7 @@ export default function Column<OptionType extends DefaultOptionType = DefaultOpt
         }) => {
           // >>>>> Open
           const triggerOpenPath = () => {
-            if (disabled || searchValue) {
+            if (disabled) {
               return;
             }
             const nextValueCells = [...fullPath];

--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -166,7 +166,9 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
 
   // >>>>> Active Scroll
   React.useEffect(() => {
-    if (searchValue) return;
+    if (searchValue) {
+      return;
+    }
     for (let i = 0; i < activeValueCells.length; i += 1) {
       const cellPath = activeValueCells.slice(0, i + 1);
       const cellKeyPath = toPathKey(cellPath);

--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -166,6 +166,7 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
 
   // >>>>> Active Scroll
   React.useEffect(() => {
+    if (searchValue) return;
     for (let i = 0; i < activeValueCells.length; i += 1) {
       const cellPath = activeValueCells.slice(0, i + 1);
       const cellKeyPath = toPathKey(cellPath);
@@ -176,7 +177,7 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
         scrollIntoParentView(ele);
       }
     }
-  }, [activeValueCells]);
+  }, [activeValueCells, searchValue]);
 
   // ========================== Render ==========================
   // >>>>> Empty
@@ -213,7 +214,6 @@ const RawOptionList = React.forwardRef<RefOptionListProps, RawOptionListProps>((
       <Column
         key={index}
         {...columnProps}
-        searchValue={searchValue}
         prefixCls={mergedPrefixCls}
         options={col.options}
         prevValuePath={prevValuePath}

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -6,7 +6,7 @@ import Cascader from '../src';
 import { addressOptions, addressOptionsForUneven, optionsForActiveMenuItems } from './demoOptions';
 import { mount } from './enzyme';
 import { toRawValues } from '../src/utils/commonUtil';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Cascader.Basic', () => {
   let selectedValue: any;
@@ -1021,6 +1021,85 @@ describe('Cascader.Basic', () => {
 
       wrapper.find(`li[data-path-key]`).at(0).simulate('click');
       wrapper.find(`li[data-path-key]`).at(1).simulate('click');
+    });
+    it('hover + search', () => {
+      let getOffesetTopTimes = 0;
+      const spyElement = spyElementPrototypes(HTMLElement, {
+        offsetTop: {
+          get: () => (getOffesetTopTimes++ % 2 === 0 ? 100 : 0),
+        },
+        scrollTop: {
+          get: () => 0,
+        },
+        offsetHeight: {
+          get: () => 10,
+        },
+      });
+
+      const wrapper = render(
+        <Cascader
+          expandTrigger="hover"
+          options={[
+            {
+              label: 'Women Clothing',
+              value: '1',
+              children: [
+                {
+                  label: 'Women Tops, Blouses & Tee',
+                  value: '11',
+                  children: [
+                    {
+                      label: 'Women T-Shirts',
+                      value: '111',
+                    },
+                    {
+                      label: 'Women Tops',
+                      value: '112',
+                    },
+                    {
+                      label: 'Women Tank Tops & Camis',
+                      value: '113',
+                    },
+                    {
+                      label: 'Women Blouses',
+                      value: '114',
+                    },
+                  ],
+                },
+                {
+                  label: 'Women Suits',
+                  value: '2',
+                  children: [
+                    {
+                      label: 'Women Suit Pants',
+                      value: '21',
+                    },
+                    {
+                      label: 'Women Suit Sets',
+                      value: '22',
+                    },
+                    {
+                      label: 'Women Blazers',
+                      value: '23',
+                    },
+                  ],
+                },
+              ],
+            },
+          ]}
+          showSearch
+          checkable
+          open
+        />,
+      );
+      fireEvent.change(wrapper.container.querySelector('input') as HTMLElement, {
+        target: { value: 'w' },
+      });
+      const items = wrapper.container.querySelectorAll('.rc-cascader-menu-item');
+      fireEvent.mouseEnter(items[9]);
+      expect(mockScrollTo).toHaveBeenCalledTimes(0);
+
+      spyElement.mockRestore();
     });
   });
 


### PR DESCRIPTION
优化为 searchValue 有值，阻止滚动，解决搜索结果选中后，没有默认激活当前选中项

优化前

https://github.com/user-attachments/assets/7454e797-c174-46b6-90e5-3f41396d25fa

优化后

https://github.com/user-attachments/assets/a19d8d2b-037e-4796-9e7d-288f12f2e190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 改进了组件在搜索时的滚动行为，确保在有活动搜索时不会执行滚动逻辑。
- **bug 修复**
	- 简化了组件逻辑，移除了对 `searchValue` 的依赖，确保组件行为更直接。
- **文档**
	- 增强了对 `Cascader` 组件的测试覆盖，验证了其在特定用户交互下的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->