### PR TITLE
fix: antd-issue-51248

### DIFF
--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,4 +1,3 @@
-
 import warning from 'rc-util/lib/warning';
 import * as React from 'react';
 import type { CascaderProps, ShowSearchType } from '../Cascader';
@@ -22,8 +21,8 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
       };
     }
 
-    if ((searchConfig.limit as number) <= 0) {
-      searchConfig.limit = false;
+    if ((searchConfig.limit as number) <= 0 && searchConfig.limit !== false) {
+      delete searchConfig.limit;
 
       if (process.env.NODE_ENV !== 'production') {
         warning(false, "'limit' of showSearch should be positive number or false.");

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -21,8 +21,8 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
       };
     }
 
-    if ((searchConfig.limit as number) <= 0 && searchConfig.limit !== false) {
-      delete searchConfig.limit;
+    if ((searchConfig.limit as number) <= 0) {
+      searchConfig.limit = false;
 
       if (process.env.NODE_ENV !== 'production') {
         warning(false, "'limit' of showSearch should be positive number or false.");

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,3 +1,4 @@
+
 import warning from 'rc-util/lib/warning';
 import * as React from 'react';
 import type { CascaderProps, ShowSearchType } from '../Cascader';
@@ -22,7 +23,7 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
     }
 
     if ((searchConfig.limit as number) <= 0) {
-      delete searchConfig.limit;
+      searchConfig.limit = false;
 
       if (process.env.NODE_ENV !== 'production') {
         warning(false, "'limit' of showSearch should be positive number or false.");

--- a/tests/search.limit.spec.tsx
+++ b/tests/search.limit.spec.tsx
@@ -13,8 +13,7 @@ describe('Cascader.Search', () => {
   }
   const options = [
     {
-      region: 'Asia',
-      children: [],
+      children: [] as any[],
       isParent: true,
       label: 'Asia',
       value: 'Asia',
@@ -22,7 +21,6 @@ describe('Cascader.Search', () => {
   ];
   for (let i = 0; i < 100; i++) {
     options[0].children.push({
-      id: i,
       label: 'label' + i,
       value: 'value' + i,
     });

--- a/tests/search.limit.spec.tsx
+++ b/tests/search.limit.spec.tsx
@@ -55,7 +55,7 @@ describe('Cascader.Search', () => {
 
     doSearch(wrapper, 'as');
     const itemList = wrapper.find('div.rc-cascader-menu-item-content');
-    expect(itemList).toHaveLength(50);
+    expect(itemList).toHaveLength(100);
   });
 
   it('limit', () => {

--- a/tests/search.limit.spec.tsx
+++ b/tests/search.limit.spec.tsx
@@ -41,4 +41,36 @@ describe('Cascader.Search', () => {
     const itemList = wrapper.find('div.rc-cascader-menu-item-content');
     expect(itemList).toHaveLength(itemList.length);
   });
+
+  it('limit', () => {
+    const wrapper = mount(
+      <Cascader
+        options={options}
+        open
+        showSearch={{
+          limit: 0,
+        }}
+      />,
+    );
+
+    doSearch(wrapper, 'as');
+    const itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(50);
+  });
+
+  it('limit', () => {
+    const wrapper = mount(
+      <Cascader
+        options={options}
+        open
+        showSearch={{
+          limit: 20,
+        }}
+      />,
+    );
+
+    doSearch(wrapper, 'as');
+    const itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(20);
+  });
 });

--- a/tests/search.limit.spec.tsx
+++ b/tests/search.limit.spec.tsx
@@ -39,7 +39,7 @@ describe('Cascader.Search', () => {
 
     doSearch(wrapper, 'as');
     const itemList = wrapper.find('div.rc-cascader-menu-item-content');
-    expect(itemList).toHaveLength(itemList.length);
+    expect(itemList).toHaveLength(100);
   });
 
   it('limit', () => {

--- a/tests/search.limit.spec.tsx
+++ b/tests/search.limit.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Cascader from '../src';
+import type { ReactWrapper } from './enzyme';
+import { mount } from './enzyme';
+
+describe('Cascader.Search', () => {
+  function doSearch(wrapper: ReactWrapper, search: string) {
+    wrapper.find('input').simulate('change', {
+      target: {
+        value: search,
+      },
+    });
+  }
+  const options = [
+    {
+      region: 'Asia',
+      children: [],
+      isParent: true,
+      label: 'Asia',
+      value: 'Asia',
+    },
+  ];
+  for (let i = 0; i < 100; i++) {
+    options[0].children.push({
+      id: i,
+      label: 'label' + i,
+      value: 'value' + i,
+    });
+  }
+
+  it('limit', () => {
+    const wrapper = mount(
+      <Cascader
+        options={options}
+        open
+        showSearch={{
+          limit: false,
+        }}
+      />,
+    );
+
+    doSearch(wrapper, 'as');
+    const itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(itemList.length);
+  });
+});


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/51248

searchConfig.limit <= 0 时重新赋值为 false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了搜索配置处理逻辑，限制属性现在设置为`false`而不是被删除。
	- 在非生产环境中，如果限制不是正数或设置为`false`，将发出警告。
- **测试**
	- 新增了针对`Cascader.Search`组件的测试套件，确保组件在不同限制条件下的行为符合预期。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->