### PR TITLE
Add displayInInput option to allow externally controlled search

### DIFF
--- a/docs/demo/external-search.md
+++ b/docs/demo/external-search.md
@@ -1,0 +1,8 @@
+---
+title: external search
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../../examples/external-search.tsx"></code>

--- a/examples/external-search.tsx
+++ b/examples/external-search.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import '../assets/index.less';
+import Cascader from '../src';
+
+const addressOptions = [
+  {
+    label: '福建',
+    value: 'fj',
+    children: [
+      {
+        label: '福州',
+        value: 'fuzhou',
+        children: [
+          {
+            label: '马尾-mw',
+            value: 'mawei',
+          },
+        ],
+      },
+      {
+        label: '泉州-qz',
+        value: 'quanzhou',
+      },
+    ],
+  },
+  {
+    label: '浙江',
+    value: 'zj',
+    children: [
+      {
+        label: '杭州',
+        value: 'hangzhou',
+        children: [
+          {
+            label: '余杭',
+            value: 'yuhang',
+          },
+          {
+            label: '福州',
+            value: 'fuzhou',
+            children: [
+              {
+                label: '马尾',
+                value: 'mawei',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: '北京',
+    value: 'bj',
+    children: [
+      {
+        label: '朝阳区',
+        value: 'chaoyang',
+      },
+      {
+        label: '海淀区',
+        value: 'haidian',
+      },
+    ],
+  },
+];
+
+const Demo = () => {
+  const [searchValue, setSearchValue] = useState('');
+  return (
+    <>
+      <Cascader
+        options={addressOptions}
+        showSearch={{ displayInInput: false }}
+        searchValue={searchValue}
+        style={{ width: 300 }}
+        dropdownRender={menu => {
+          return (
+            <div>
+              <input
+                value={searchValue}
+                onChange={e => setSearchValue(e.target.value)}
+                placeholder="External Search"
+              />
+              {menu}
+            </div>
+          );
+        }}
+        animation="slide-up"
+        notFoundContent="Empty Content!"
+      />
+    </>
+  );
+};
+
+export default Demo;

--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -57,6 +57,7 @@ export interface ShowSearchType<
     inputValue: string,
     fieldNames: FieldNames<OptionType, ValueField>,
   ) => number;
+  displayInInput?: boolean;
   matchInputWidth?: boolean;
   limit?: number | false;
 }

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -12,6 +12,7 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
     let searchConfig: ShowSearchType = {
       matchInputWidth: true,
       limit: 50,
+      displayInInput: true,
     };
 
     if (showSearch && typeof showSearch === 'object') {
@@ -29,6 +30,6 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
       }
     }
 
-    return [true, searchConfig];
+    return [!!searchConfig.displayInInput, searchConfig];
   }, [showSearch]);
 }

--- a/tests/search.spec.tsx
+++ b/tests/search.spec.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
 import { resetWarned } from 'rc-util/lib/warning';
-import React from 'react';
+import React, { useState } from 'react';
 import Cascader from '../src';
 import { optionsForActiveMenuItems } from './demoOptions';
 import type { ReactWrapper } from './enzyme';
@@ -72,6 +72,49 @@ describe('Cascader.Search', () => {
     wrapper.clickOption(0, 0);
     expect(onChange).toHaveBeenCalledWith(['bamboo', 'little', 'fish'], expect.anything());
   });
+
+  it('externally controlled search',() => {
+    const onSearch = jest.fn();
+    const onChange = jest.fn();
+
+    function doExternalSearch(wrapper: ReactWrapper, search: string) {
+      wrapper.find('input[data-test="external-search"]').simulate('change', {
+        target: {
+          value: search,
+        },
+      });
+    }
+
+
+    const ExternallyControlledSearch = () => {
+      const [searchValue,setSearchValue] = useState('')
+      return (
+        <>
+          <input data-test="external-search" value={searchValue} onChange={e => setSearchValue(e.target.value)} />
+          <Cascader options={options} searchValue={searchValue} onChange={onChange} onSearch={onSearch} open showSearch={{displayInInput:false}} />,
+        </>      
+      );
+    }
+    const wrapper = mount(<ExternallyControlledSearch/>)
+
+    // Leaf
+    doExternalSearch(wrapper, 'toy');
+    let itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(2);
+    expect(itemList.at(0).text()).toEqual('Label Bamboo / Label Little / Toy Fish');
+    expect(itemList.at(1).text()).toEqual('Label Bamboo / Label Little / Toy Cards');
+
+    // Parent
+    doExternalSearch(wrapper, 'Label Little');
+    itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(2);
+    expect(itemList.at(0).text()).toEqual('Label Bamboo / Label Little / Toy Fish');
+    expect(itemList.at(1).text()).toEqual('Label Bamboo / Label Little / Toy Cards');
+
+    // Change
+    wrapper.clickOption(0, 0);
+    expect(onChange).toHaveBeenCalledWith(['bamboo', 'little', 'fish'], expect.anything());
+  })
 
   it('changeOnSelect', () => {
     const onChange = jest.fn();


### PR DESCRIPTION
cascader accepts a `searchValue` prop which means it can be externally controlled. 

This implies that the search can come from anywhere outside. 

I have a usecase where I want an external field - one I render inside the dropdown menu -  to control the search value for cascader, but I don't want to display this value in the Cascader's input. 

I've included updated code, a demo, and a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 更新了文档文件`external-search.md`，提供外部搜索功能的演示文档。
  - 引入了`Demo`组件，允许用户通过`Cascader`组件进行层级地址数据的搜索。
  - 在`Cascader`组件中增加了`displayInInput`属性，以增强搜索输入的显示控制。

- **测试**
  - 为`Cascader.Search`组件添加了新的测试用例，验证外部控制搜索功能的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->