### PR TITLE
chore: bump rc-tree version to 5.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@babel/runtime": "^7.25.7",
     "classnames": "^2.3.1",
     "rc-select": "~14.16.2",
-    "rc-tree": "~5.10.1",
+    "rc-tree": "~5.11.0",
     "rc-util": "^5.43.0"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **更新内容**
	- 更新了 `rc-tree` 依赖的版本，从 `~5.10.1` 升级到 `~5.11.0`，可能包含了错误修复或新功能。
	- 进行了轻微的格式更改，移除了文件末尾的换行符。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->