### PR TITLE
[WIP]feat: Merge searchValue and onSearch into the showSearch field

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,6 @@ React.render(
   </thead>
   <tbody>
     <tr>
-      <td>autoClearSearchValue</td>
-      <td>boolean</td>
-      <td>true</td>
-      <td>Whether the current search will be cleared on selecting an item. Only applies when checkable</td>
-    </tr>
-    <tr>
       <td>options</td>
       <td>Object</td>
       <td></td>
@@ -234,8 +228,27 @@ React.render(
       <td>>true</td>
       <td>hide popup on select</td>
     </tr>
+     <tr>
+      <td>showSearch</td>
+      <td>Boolean | Object</td>
+      <td>>false</td>
+      <td>hide popup on select</td>
+    </tr>
   </tbody>
 </table>
+
+### showSearch
+
+| Property | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| autoClearSearchValue | Whether the current search will be cleared on selecting an item. Only applies when checkable| boolean | true |
+| filter | The function will receive two arguments, inputValue and option, if the function returns true, the option will be included in the filtered set; Otherwise, it will be excluded | function(inputValue, path): boolean | - |  |
+| limit | Set the count of filtered items | number \| false | 50 |  |
+| matchInputWidth | Whether the width of list matches input, ([how it looks](https://github.com/ant-design/ant-design/issues/25779)) | boolean | true |  |
+| render | Used to render filtered options | function(inputValue, path): ReactNode | - |  |
+| sort | Used to sort filtered options | function(a, b, inputValue) | - |  |
+| searchValue | The current input "search" text | string | - |
+| onSearch | called when input changed | function | - |
 
 ### option
 

--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -63,6 +63,8 @@ export interface ShowSearchType<
   ) => number;
   matchInputWidth?: boolean;
   limit?: number | false;
+  searchValue?: string;
+  onSearch?: (value: string) => void;
 }
 
 export type ShowCheckedStrategy = typeof SHOW_PARENT | typeof SHOW_CHILD;
@@ -90,7 +92,9 @@ interface BaseCascaderProps<
   // Search
   autoClearSearchValue?: boolean;
   showSearch?: boolean | ShowSearchType<OptionType>;
+  /** @deprecated please use showSearch */
   searchValue?: string;
+  /** @deprecated please use showSearch */
   onSearch?: (value: string) => void;
 
   // Trigger
@@ -268,15 +272,15 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
 
   // =========================== Search ===========================
   const [mergedSearchValue, setSearchValue] = useMergedState('', {
-    value: searchValue,
+    value: (showSearch as ShowSearchType)?.searchValue ?? searchValue,
     postState: search => search || '',
   });
 
   const onInternalSearch: BaseSelectProps['onSearch'] = (searchText, info) => {
     setSearchValue(searchText);
-
-    if (info.source !== 'blur' && onSearch) {
-      onSearch(searchText);
+    const search = (showSearch as ShowSearchType)?.onSearch ?? onSearch;
+    if (info.source !== 'blur' && search) {
+      search(searchText);
     }
   };
 

--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -40,7 +40,7 @@ export interface BaseOptionType {
 
 export type DefaultOptionType = BaseOptionType & Record<string, any>;
 
-export interface ShowSearchType<
+export interface SearchConfig<
   OptionType extends DefaultOptionType = DefaultOptionType,
   ValueField extends keyof OptionType = keyof OptionType,
 > {
@@ -65,6 +65,7 @@ export interface ShowSearchType<
   limit?: number | false;
   searchValue?: string;
   onSearch?: (value: string) => void;
+  autoClearSearchValue?: boolean;
 }
 
 export type ShowCheckedStrategy = typeof SHOW_PARENT | typeof SHOW_CHILD;
@@ -90,11 +91,12 @@ interface BaseCascaderProps<
   showCheckedStrategy?: ShowCheckedStrategy;
 
   // Search
+  /** @deprecated please use showSearch.autoClearSearchValue */
   autoClearSearchValue?: boolean;
-  showSearch?: boolean | ShowSearchType<OptionType>;
-  /** @deprecated please use showSearch */
+  showSearch?: boolean | SearchConfig<OptionType>;
+  /** @deprecated please use showSearch.searchValue */
   searchValue?: string;
-  /** @deprecated please use showSearch */
+  /** @deprecated please use showSearch.onSearch */
   onSearch?: (value: string) => void;
 
   // Trigger
@@ -271,20 +273,19 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
   );
 
   // =========================== Search ===========================
+  const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch);
   const [mergedSearchValue, setSearchValue] = useMergedState('', {
-    value: (showSearch as ShowSearchType)?.searchValue ?? searchValue,
+    value: searchConfig?.searchValue ?? searchValue,
     postState: search => search || '',
   });
 
   const onInternalSearch: BaseSelectProps['onSearch'] = (searchText, info) => {
     setSearchValue(searchText);
-    const search = (showSearch as ShowSearchType)?.onSearch ?? onSearch;
+    const search = searchConfig?.onSearch ?? onSearch;
     if (info.source !== 'blur' && search) {
       search(searchText);
     }
   };
-
-  const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch);
 
   const searchOptions = useSearchOptions(
     mergedSearchValue,
@@ -455,7 +456,7 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
         ref={ref as any}
         id={mergedId}
         prefixCls={prefixCls}
-        autoClearSearchValue={autoClearSearchValue}
+        autoClearSearchValue={searchConfig?.autoClearSearchValue ?? autoClearSearchValue}
         popupMatchSelectWidth={popupMatchSelectWidth}
         classNames={{
           prefix: classNames?.prefix,

--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -211,9 +211,6 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
     checkable,
 
     // Search
-    autoClearSearchValue = true,
-    searchValue,
-    onSearch,
     showSearch,
 
     // Trigger
@@ -273,17 +270,17 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
   );
 
   // =========================== Search ===========================
-  const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch);
+  const [mergedShowSearch, searchConfig] = useSearchConfig(showSearch, props);
+  const { autoClearSearchValue = true, searchValue, onSearch } = searchConfig;
   const [mergedSearchValue, setSearchValue] = useMergedState('', {
-    value: searchConfig?.searchValue ?? searchValue,
+    value: searchValue,
     postState: search => search || '',
   });
 
   const onInternalSearch: BaseSelectProps['onSearch'] = (searchText, info) => {
     setSearchValue(searchText);
-    const search = searchConfig?.onSearch ?? onSearch;
-    if (info.source !== 'blur' && search) {
-      search(searchText);
+    if (info.source !== 'blur' && onSearch) {
+      onSearch(searchText);
     }
   };
 
@@ -456,7 +453,7 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
         ref={ref as any}
         id={mergedId}
         prefixCls={prefixCls}
-        autoClearSearchValue={searchConfig?.autoClearSearchValue ?? autoClearSearchValue}
+        autoClearSearchValue={autoClearSearchValue}
         popupMatchSelectWidth={popupMatchSelectWidth}
         classNames={{
           prefix: classNames?.prefix,

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -3,7 +3,8 @@ import * as React from 'react';
 import type { CascaderProps, SearchConfig } from '../Cascader';
 
 // Convert `showSearch` to unique config
-export default function useSearchConfig(showSearch?: CascaderProps['showSearch']) {
+export default function useSearchConfig(showSearch?: CascaderProps['showSearch'], props?: any) {
+  const { autoClearSearchValue, searchValue, onSearch } = props;
   return React.useMemo<[boolean, SearchConfig]>(() => {
     if (!showSearch) {
       return [false, {}];
@@ -12,6 +13,9 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
     let searchConfig: SearchConfig = {
       matchInputWidth: true,
       limit: 50,
+      autoClearSearchValue,
+      searchValue,
+      onSearch,
     };
 
     if (showSearch && typeof showSearch === 'object') {
@@ -30,5 +34,5 @@ export default function useSearchConfig(showSearch?: CascaderProps['showSearch']
     }
 
     return [true, searchConfig];
-  }, [showSearch]);
+  }, [showSearch, autoClearSearchValue, searchValue, onSearch]);
 }

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,15 +1,15 @@
 import warning from '@rc-component/util/lib/warning';
 import * as React from 'react';
-import type { CascaderProps, ShowSearchType } from '../Cascader';
+import type { CascaderProps, SearchConfig } from '../Cascader';
 
 // Convert `showSearch` to unique config
 export default function useSearchConfig(showSearch?: CascaderProps['showSearch']) {
-  return React.useMemo<[boolean, ShowSearchType]>(() => {
+  return React.useMemo<[boolean, SearchConfig]>(() => {
     if (!showSearch) {
       return [false, {}];
     }
 
-    let searchConfig: ShowSearchType = {
+    let searchConfig: SearchConfig = {
       matchInputWidth: true,
       limit: 50,
     };

--- a/src/hooks/useSearchOptions.ts
+++ b/src/hooks/useSearchOptions.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import type { DefaultOptionType, InternalFieldNames, ShowSearchType } from '../Cascader';
+import type { DefaultOptionType, InternalFieldNames, SearchConfig } from '../Cascader';
 
 export const SEARCH_MARK = '__rc_cascader_search_mark__';
 
-const defaultFilter: ShowSearchType['filter'] = (search, options, { label = '' }) =>
+const defaultFilter: SearchConfig['filter'] = (search, options, { label = '' }) =>
   options.some(opt => String(opt[label]).toLowerCase().includes(search.toLowerCase()));
 
-const defaultRender: ShowSearchType['render'] = (inputValue, path, prefixCls, fieldNames) =>
+const defaultRender: SearchConfig['render'] = (inputValue, path, prefixCls, fieldNames) =>
   path.map(opt => opt[fieldNames.label as string]).join(' / ');
 
 const useSearchOptions = (
@@ -14,7 +14,7 @@ const useSearchOptions = (
   options: DefaultOptionType[],
   fieldNames: InternalFieldNames,
   prefixCls: string,
-  config: ShowSearchType,
+  config: SearchConfig,
   enableHalfPath?: boolean,
 ) => {
   const { filter = defaultFilter, render = defaultRender, limit = 50, sort } = config;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ export type {
   DefaultOptionType,
   CascaderProps,
   FieldNames,
-  ShowSearchType,
+  SearchConfig,
   CascaderRef,
 } from './Cascader';
 export { Panel };

--- a/tests/search.spec.tsx
+++ b/tests/search.spec.tsx
@@ -308,6 +308,7 @@ describe('Cascader.Search', () => {
       <Cascader
         open
         searchValue="little"
+        showSearch
         options={[
           {
             label: 'bamboo',
@@ -397,5 +398,34 @@ describe('Cascader.Search', () => {
     expect(
       (container.querySelector('.rc-cascader-selection-search-input') as HTMLInputElement)?.value,
     ).toBe('little');
+  });
+  it('autoClearSearchValue in showSearch', () => {
+    const { container } = render(
+      <Cascader
+        open
+        checkable
+        showSearch={{ autoClearSearchValue: false }}
+        options={[
+          {
+            label: 'bamboo',
+            value: 'bamboo',
+            children: [
+              {
+                label: 'little',
+                value: 'little',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const inputNode = container.querySelector<HTMLInputElement>(
+      '.rc-cascader-selection-search-input',
+    );
+    fireEvent.change(inputNode as HTMLInputElement, { target: { value: 'little' } });
+    expect(inputNode).toHaveValue('little');
+    fireEvent.click(document.querySelector('.rc-cascader-checkbox') as HTMLElement);
+    expect(inputNode).toHaveValue('little');
   });
 });

--- a/tests/search.spec.tsx
+++ b/tests/search.spec.tsx
@@ -352,4 +352,50 @@ describe('Cascader.Search', () => {
       '{"label":"bamboo","disabled":true,"value":"bamboo"}',
     );
   });
+
+  it('onSearch and searchValue in showSearch', () => {
+    const onSearch = jest.fn();
+    const wrapper = mount(<Cascader options={options} open showSearch={{ onSearch }} />);
+
+    // Leaf
+    doSearch(wrapper, 'toy');
+    let itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(2);
+    expect(itemList.at(0).text()).toEqual('Label Bamboo / Label Little / Toy Fish');
+    expect(itemList.at(1).text()).toEqual('Label Bamboo / Label Little / Toy Cards');
+    expect(onSearch).toHaveBeenCalledWith('toy');
+
+    // Parent
+    doSearch(wrapper, 'Label Little');
+    itemList = wrapper.find('div.rc-cascader-menu-item-content');
+    expect(itemList).toHaveLength(2);
+    expect(itemList.at(0).text()).toEqual('Label Bamboo / Label Little / Toy Fish');
+    expect(itemList.at(1).text()).toEqual('Label Bamboo / Label Little / Toy Cards');
+    expect(onSearch).toHaveBeenCalledWith('Label Little');
+  });
+
+  it('searchValue in showSearch', () => {
+    const { container } = render(
+      <Cascader
+        open
+        showSearch={{ searchValue: 'little' }}
+        options={[
+          {
+            label: 'bamboo',
+            value: 'bamboo',
+            children: [
+              {
+                label: 'little',
+                value: 'little',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(container.querySelectorAll('.rc-cascader-menu-item')).toHaveLength(1);
+    expect(
+      (container.querySelector('.rc-cascader-selection-search-input') as HTMLInputElement)?.value,
+    ).toBe('little');
+  });
 });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/33482 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 级联选择器的搜索配置现支持通过 `showSearch` 对象集中设置搜索值和搜索回调。
- **测试**
  - 新增用例，验证通过 `showSearch` 配置搜索值和回调时的行为是否正确。
- **文档**
  - 顶层 `searchValue` 和 `onSearch` 属性已标记为弃用，建议改用 `showSearch` 配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->