### PR TITLE
feat: Panel use optionRender

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -36,7 +36,8 @@ export type PickType =
   | 'style'
   | 'direction'
   | 'notFoundContent'
-  | 'disabled';
+  | 'disabled'
+  | 'optionRender';
 
 export type PanelProps<
   OptionType extends DefaultOptionType = DefaultOptionType,
@@ -70,6 +71,7 @@ export default function Panel<
     direction,
     notFoundContent = 'Not Found',
     disabled,
+    optionRender,
   } = props as Pick<InternalCascaderProps, PickType>;
 
   // ======================== Multiple ========================
@@ -159,6 +161,7 @@ export default function Panel<
       expandIcon,
       loadingIcon,
       popupMenuColumnStyle: undefined,
+      optionRender
     }),
     [
       mergedOptions,
@@ -172,6 +175,7 @@ export default function Panel<
       expandTrigger,
       expandIcon,
       loadingIcon,
+      optionRender,
     ],
   );
 

--- a/tests/Panel.spec.tsx
+++ b/tests/Panel.spec.tsx
@@ -110,4 +110,25 @@ describe('Cascader.Panel', () => {
     fireEvent.click(selectOption);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('Should optionRender work in Panel', () => {
+    const { container, rerender } = render(
+      <Cascader.Panel
+        options={[{ label: 'bamboo', value: 'bamboo' }]}
+        optionRender={option => `${option.label} - test`}
+      />,
+    );
+    expect(container.querySelector('.rc-cascader-menu-item-content')?.innerHTML).toEqual(
+      'bamboo - test',
+    );
+    rerender(
+      <Cascader.Panel
+        options={[{ label: 'bamboo', disabled: true, value: 'bamboo' }]}
+        optionRender={option => JSON.stringify(option)}
+      />,
+    );
+    expect(container.querySelector('.rc-cascader-menu-item-content')?.innerHTML).toEqual(
+      '{"label":"bamboo","disabled":true,"value":"bamboo"}',
+    );
+  });
 });


### PR DESCRIPTION
相关issue：https://github.com/ant-design/ant-design/issues/54839
Panel 支持使用optionRender自定义渲染选项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - Panel 组件新增 optionRender 属性，支持自定义选项渲染；该配置向下传递至子组件，变更后可即时生效。

- 测试
  - 新增针对 Panel 中 optionRender 的单元测试，覆盖普通与禁用选项的渲染结果与动态更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->