### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/examples/adjust-overflow.tsx
+++ b/examples/adjust-overflow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import type { BuildInPlacements } from '@rc-component/trigger/lib/interface';
+import type { BuildInPlacements } from '@rc-component/trigger';
 import '../assets/index.less';
 import type { CascaderProps } from '../src';
 import Cascader from '../src';

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "test": "rc-test"
   },
   "dependencies": {
-    "@rc-component/select": "~1.7.0",
-    "@rc-component/tree": "~1.3.0",
-    "@rc-component/util": "^1.4.0",
+    "@rc-component/select": "~1.7.1",
+    "@rc-component/tree": "~1.3.2",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/form": "^1.4.0",
     "@rc-component/np": "^1.0.3",
     "@rc-component/trigger": "^3.0.0",

--- a/src/Cascader.tsx
+++ b/src/Cascader.tsx
@@ -1,14 +1,11 @@
-import type { BuildInPlacements } from '@rc-component/trigger/lib/interface';
+import type { BuildInPlacements } from '@rc-component/trigger';
 import type {
   BaseSelectProps,
   BaseSelectPropsWithoutPrivate,
   BaseSelectRef,
 } from '@rc-component/select';
 import { BaseSelect } from '@rc-component/select';
-import type { DisplayValueType, Placement } from '@rc-component/select/lib/BaseSelect';
-import useId from '@rc-component/util/lib/hooks/useId';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
+import { useControlledState, useEvent, useId } from '@rc-component/util';
 import * as React from 'react';
 import CascaderContext from './context';
 import useDisplayValues from './hooks/useDisplayValues';
@@ -111,7 +108,7 @@ interface BaseCascaderProps<
   popupClassName?: string;
   popupMenuColumnStyle?: React.CSSProperties;
 
-  placement?: Placement;
+  placement?: BaseSelectPropsWithoutPrivate['placement'];
   builtinPlacements?: BuildInPlacements;
 
   onPopupVisibleChange?: (open: boolean) => void;
@@ -381,7 +378,9 @@ const Cascader = React.forwardRef<CascaderRef, InternalCascaderProps>((props, re
     }
 
     // Cascader do not support `add` type. Only support `remove`
-    const { valueCells } = info.values[0] as DisplayValueType & { valueCells: SingleValueType };
+    const { valueCells } = info.values[0] as BaseSelectProps['displayValues'][number] & {
+      valueCells: SingleValueType;
+    };
     onInternalSelect(valueCells);
   };
 

--- a/src/OptionList/Column.tsx
+++ b/src/OptionList/Column.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import * as React from 'react';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { pickAttrs } from '@rc-component/util';
 import type { DefaultOptionType, SingleValueType } from '../Cascader';
 import CascaderContext from '../context';
 import { SEARCH_MARK } from '../hooks/useSearchOptions';

--- a/src/OptionList/List.tsx
+++ b/src/OptionList/List.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable default-case */
 import { clsx } from 'clsx';
-import type { useBaseProps } from '@rc-component/select';
-import type { RefOptionListProps } from '@rc-component/select/lib/OptionList';
+import type { BaseSelectProps, useBaseProps } from '@rc-component/select';
 import * as React from 'react';
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
+import { useMemo } from '@rc-component/util';
 import type { DefaultOptionType, LegacyKey, SingleValueType } from '../Cascader';
 import CascaderContext from '../context';
 import {
@@ -18,6 +17,13 @@ import { toPathOptions } from '../utils/treeUtil';
 import Column, { FIX_LABEL } from './Column';
 import useActive from './useActive';
 import useKeyboard from './useKeyboard';
+
+export type RefOptionListProps =
+  NonNullable<React.ComponentProps<BaseSelectProps['OptionList']>['ref']> extends React.Ref<
+    infer Ref
+  >
+    ? Ref
+    : never;
 
 export type RawOptionListProps = Pick<
   ReturnType<typeof useBaseProps>,

--- a/src/OptionList/index.tsx
+++ b/src/OptionList/index.tsx
@@ -1,7 +1,6 @@
 import { useBaseProps } from '@rc-component/select';
-import type { RefOptionListProps } from '@rc-component/select/lib/OptionList';
 import * as React from 'react';
-import RawOptionList from './List';
+import RawOptionList, { type RefOptionListProps } from './List';
 
 const RefOptionList = React.forwardRef<RefOptionListProps>((props, ref) => {
   const { lockOptions, ...baseProps } = useBaseProps();

--- a/src/OptionList/useKeyboard.ts
+++ b/src/OptionList/useKeyboard.ts
@@ -1,5 +1,4 @@
-import type { RefOptionListProps } from '@rc-component/select/lib/OptionList';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import * as React from 'react';
 import type {
   DefaultOptionType,
@@ -9,6 +8,7 @@ import type {
 } from '../Cascader';
 import { SEARCH_MARK } from '../hooks/useSearchOptions';
 import { getFullPathKeys, toPathKey } from '../utils/commonUtil';
+import type { RefOptionListProps } from './List';
 
 export default (
   ref: React.Ref<RefOptionListProps>,

--- a/src/hooks/useEntities.ts
+++ b/src/hooks/useEntities.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { convertDataToEntities } from '@rc-component/tree/lib/utils/treeUtil';
+import { convertDataToEntities } from '@rc-component/tree';
+import type { DataNode } from '@rc-component/tree';
 import type { DefaultOptionType, InternalFieldNames } from '../Cascader';
-import type { DataEntity, DataNode } from '@rc-component/tree/lib/interface';
 import { VALUE_SPLIT } from '../utils/commonUtil';
+
+export type DataEntity = ReturnType<typeof convertDataToEntities>['keyEntities'][string];
 
 export interface OptionsInfo {
   keyEntities: Record<string, DataEntity>;

--- a/src/hooks/useSearchConfig.ts
+++ b/src/hooks/useSearchConfig.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import * as React from 'react';
 import type { CascaderProps, SearchConfig } from '../Cascader';
 

--- a/src/hooks/useSelect.ts
+++ b/src/hooks/useSelect.ts
@@ -1,4 +1,4 @@
-import { conductCheck } from '@rc-component/tree/lib/utils/conductUtil';
+import { conductCheck } from '@rc-component/tree';
 import type {
   InternalValueType,
   LegacyKey,

--- a/src/hooks/useValues.ts
+++ b/src/hooks/useValues.ts
@@ -1,8 +1,8 @@
-import type { DataEntity } from '@rc-component/tree/lib/interface';
-import { conductCheck } from '@rc-component/tree/lib/utils/conductUtil';
+import { conductCheck } from '@rc-component/tree';
 import * as React from 'react';
 import type { LegacyKey, SingleValueType } from '../Cascader';
 import { toPathKeys } from '../utils/commonUtil';
+import type { DataEntity } from './useEntities';
 import type { GetMissValues } from './useMissingValues';
 
 export default function useValues(

--- a/src/utils/warningPropsUtil.ts
+++ b/src/utils/warningPropsUtil.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type { DefaultOptionType, FieldNames } from '../Cascader';
 
 // value in Cascader options should not be null

--- a/tests/__snapshots__/search.spec.tsx.snap
+++ b/tests/__snapshots__/search.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`Cascader.Search should correct render Cascader with same field name of 
     class="rc-cascader rc-cascader-single rc-cascader-open rc-cascader-show-search"
   >
     <div
-      class="rc-cascader-content"
+      class="rc-cascader-content rc-cascader-content-has-search-value"
     >
       <div
         class="rc-cascader-placeholder"

--- a/tests/fieldNames.spec.tsx
+++ b/tests/fieldNames.spec.tsx
@@ -82,7 +82,7 @@ describe('Cascader.FieldNames', () => {
       />,
     );
 
-    const contentValue = container.querySelector('.rc-cascader-content-value');
+    const contentValue = container.querySelector('.rc-cascader-content');
     expect(contentValue?.textContent).toEqual('Bamboo / Little / Toy');
 
     const menus = container.querySelectorAll('.rc-cascader-menu');
@@ -106,7 +106,7 @@ describe('Cascader.FieldNames', () => {
       />,
     );
 
-    const contentValue = container.querySelector('.rc-cascader-content-value');
+    const contentValue = container.querySelector('.rc-cascader-content');
     expect(contentValue?.textContent).toEqual('Bamboo->Little->Toy & bamboo>>little>>toy');
   });
 

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,11 +1,11 @@
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React, { useEffect, useState } from 'react';
 import type { CascaderRef, BaseOptionType, CascaderProps } from '../src';
 import Cascader from '../src';
 import { addressOptions, addressOptionsForUneven, optionsForActiveMenuItems } from './demoOptions';
 import * as commonUtil from '../src/utils/commonUtil';
 import { act, fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import { expectOpen, selectOption, isOpen, clickOption } from './util';
 
 describe('Cascader.Basic', () => {
@@ -776,7 +776,7 @@ describe('Cascader.Basic', () => {
 
   it('defaultValue not exist', () => {
     const { container } = render(<Cascader defaultValue={['not', 'exist']} />);
-    expect(container.querySelector('.rc-cascader-content-value')!.textContent).toEqual('not / exist');
+    expect(container.querySelector('.rc-cascader-content')!.textContent).toEqual('not / exist');
   });
 
   it('number value', () => {
@@ -787,7 +787,7 @@ describe('Cascader.Basic', () => {
 
     clickOption(container, 0, 0);
     expect(onValueChange).toHaveBeenCalledWith([1], expect.anything());
-    expect(container.querySelector('.rc-cascader-content-value')!.textContent).toEqual('One');
+    expect(container.querySelector('.rc-cascader-content')!.textContent).toEqual('One');
   });
 
   it('empty children is last children', () => {
@@ -837,7 +837,7 @@ describe('Cascader.Basic', () => {
         />,
       );
 
-      expect(container.querySelector('.rc-cascader-content-value')!.textContent).toEqual('Normal / Child');
+      expect(container.querySelector('.rc-cascader-content')!.textContent).toEqual('Normal / Child');
     });
 
     it('multiple', () => {

--- a/tests/keyboard.spec.tsx
+++ b/tests/keyboard.spec.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import type { CascaderProps } from '../src';
 import Cascader from '../src';
 import { addressOptions } from './demoOptions';

--- a/tests/search.spec.tsx
+++ b/tests/search.spec.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { KeyCode, resetWarned } from '@rc-component/util';
 import React from 'react';
 import Cascader, { type DefaultOptionType } from '../src';
 import { optionsForActiveMenuItems } from './demoOptions';


### PR DESCRIPTION
## 背景

antd 侧需要移除对 rc 包 `lib` / `es` 内部路径的依赖，统一改为通过 rc 包根入口使用公开 API。

关联：ant-design/ant-design#58115

## 调整

- 升级 `@rc-component/select` 到 `~1.7.1`，`@rc-component/tree` 到 `~1.3.2`
- 将 `@rc-component/select`、`@rc-component/tree` 的内部路径导入改为包根入口导入
- 对不再公开的内部类型改为基于公开类型在包内推导
- 适配 `@rc-component/select` 新版本展示节点结构，更新相关测试断言和 snapshot

## 验证

- `npm run compile`
- `npm run lint`（仅保留现有 react-hooks warning）
- `npm test -- --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级依赖版本（@rc-component/select、@rc-component/tree、@rc-component/util 等）
  * 标准化模块导入路径，统一采用包入口方式

* **Bug Fixes**
  * 修复级联选择器内容显示的 DOM 选择器问题

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/cascader/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->