### PR TITLE
chore(deps): update rc-select to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/select": "~1.8.0",
+    "@rc-component/select": "~1.9.0",
     "@rc-component/tree": "~1.3.2",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"

--- a/tests/selector.spec.tsx
+++ b/tests/selector.spec.tsx
@@ -31,7 +31,7 @@ describe('Cascader.Selector', () => {
         <Cascader value={['not', 'exist']} allowClear onChange={onChange} />,
       );
 
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect(onChange).toHaveBeenCalledWith(undefined, undefined);
     });
 
@@ -57,7 +57,7 @@ describe('Cascader.Selector', () => {
       expectOpen(container, false);
 
       // Clear
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect((global as any).activeValueCells).toEqual([]);
     });
 
@@ -67,7 +67,7 @@ describe('Cascader.Selector', () => {
         <Cascader checkable value={[['not'], ['exist']]} allowClear onChange={onChange} />,
       );
 
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect(onChange).toHaveBeenCalledWith([], []);
     });
   });
@@ -101,7 +101,7 @@ describe('Cascader.Selector', () => {
 
     const TestComponent = () => {
       const [value, setValue] = useState([['aa'], ['bb'], ['cc'], ['dd'], ['ee']]);
-      
+
       return (
         <Cascader
           options={[


### PR DESCRIPTION
## Summary
- updated `@rc-component/select` package to the latest minor version
- updated tests to use `click` event instead of `mousedown`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 升级了一个底层选择组件依赖到较新的版本，带来更稳定的兼容性与后续改进支持。

* **Tests**
  * 更新了相关清空操作的测试覆盖，确保单选和多选场景的清空行为保持一致。
  * 调整了测试触发方式，以更贴近实际点击交互。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->