### PR TITLE
chore: bump select to 1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rc-component/cascader",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "cascade select ui component for react",
   "keywords": [
     "react",
@@ -44,7 +44,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/select": "~1.8.0",
+    "@rc-component/select": "~1.9.0",
     "@rc-component/tree": "~1.3.2",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"

--- a/tests/selector.spec.tsx
+++ b/tests/selector.spec.tsx
@@ -31,7 +31,7 @@ describe('Cascader.Selector', () => {
         <Cascader value={['not', 'exist']} allowClear onChange={onChange} />,
       );
 
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect(onChange).toHaveBeenCalledWith(undefined, undefined);
     });
 
@@ -57,7 +57,7 @@ describe('Cascader.Selector', () => {
       expectOpen(container, false);
 
       // Clear
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect((global as any).activeValueCells).toEqual([]);
     });
 
@@ -67,7 +67,7 @@ describe('Cascader.Selector', () => {
         <Cascader checkable value={[['not'], ['exist']]} allowClear onChange={onChange} />,
       );
 
-      fireEvent.mouseDown(container.querySelector('.rc-cascader-clear') as HTMLElement);
+      fireEvent.click(container.querySelector('.rc-cascader-clear') as HTMLElement);
       expect(onChange).toHaveBeenCalledWith([], []);
     });
   });
@@ -101,7 +101,7 @@ describe('Cascader.Selector', () => {
 
     const TestComponent = () => {
       const [value, setValue] = useState([['aa'], ['bb'], ['cc'], ['dd'], ['ee']]);
-      
+
       return (
         <Cascader
           options={[


### PR DESCRIPTION
## Summary
- bump `@rc-component/cascader` to `1.18.0`
- update `@rc-component/select` dependency range to `~1.9.0`
- align clear interaction tests with `@rc-component/select@1.9`

## Test
- `ut run lint`
- `ut run tsc`
- `ut test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了应用版本号，并同步升级了相关组件依赖。
* **Bug Fixes**
  * 优化了清除操作的交互测试覆盖，确保单选和多选场景下的清除行为表现更稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->