### PR TITLE
ci: deploy docs after releases

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,15 @@
+name: Deploy documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    uses: react-component/rc-test/.github/workflows/deploy-pages.yml@main

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "compile": "father build",
     "coverage": "father test --coverage",
     "tsc": "tsc --noEmit",
-    "deploy": "UMI_ENV=gh npm run build && gh-pages -d docs-dist",
+    "deploy": "cross-env GH_PAGES=1 npm run build && gh-pages -d docs-dist",
     "lint": "eslint src/ examples/ tests/ --ext .tsx,.ts,.jsx,.js",
     "prepublishOnly": "npm run compile && rc-np",
     "prettier": "prettier --write --ignore-unknown .",


### PR DESCRIPTION
## Summary

- build documentation with the GitHub Pages base path
- deploy the current documentation whenever a release is published
- use the shared rc Pages workflow from `react-component/rc-test`

## Verification

- `GH_PAGES=1 ut run build`
- workflow YAML syntax validation
- caller matches the organization workflow template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增文档自动部署流程，支持发布版本后自动部署，也可手动触发。
* **改进**
  * 优化文档发布脚本，提升构建与部署流程在不同环境下的兼容性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->