### PR TITLE
chore: bump tree to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@rc-component/select": "~1.10.0",
-    "@rc-component/tree": "~1.3.2",
+    "@rc-component/tree": "~1.4.0",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },


### PR DESCRIPTION
## Summary

- bump `@rc-component/tree` from `~1.3.2` to `~1.4.0`

## Validation

- `ut test -- --runInBand`
- `ut tsc`
- `ut lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新树形组件依赖版本，带来更稳定的树形结构展示与交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->