### PR TITLE
chore(deps): upgrade @rc-component/select to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/select": "~1.10.0",
+    "@rc-component/select": "~1.11.0",
     "@rc-component/tree": "~1.5.0",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"


### PR DESCRIPTION
Upgrade `@rc-component/select` from `~1.10.0` to `~1.11.0` to consume the virtual option accessibility improvements from react-component/select#1226.

Validation:
- `ut run test -- --runInBand`
- `ut run tsc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新选择控件相关组件版本，带来更稳定且兼容性更好的运行体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->