### PR TITLE
fix: keep disabled options inert on double click

### DIFF
--- a/src/OptionList/Column.tsx
+++ b/src/OptionList/Column.tsx
@@ -192,7 +192,7 @@ export default function Column<OptionType extends DefaultOptionType = DefaultOpt
                 }
               }}
               onDoubleClick={() => {
-                if (changeOnSelect) {
+                if (changeOnSelect && !isOptionDisabled(disabled)) {
                   onToggleOpen(false);
                 }
               }}

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -558,6 +558,23 @@ describe('Cascader.Basic', () => {
     expectOpen(container, false);
   });
 
+  it('should keep popup open when double clicking a disabled option', () => {
+    const options = addressOptions.map((option, index) => ({
+      ...option,
+      disabled: index === 0,
+    }));
+    const { container } = render(
+      <Cascader options={options} changeOnSelect>
+        <input readOnly />
+      </Cascader>,
+    );
+
+    fireEvent.click(container.querySelector('input')!);
+    expectOpen(container, true);
+    selectOption(container, 0, 0, 'doubleClick');
+    expectOpen(container, true);
+  });
+
   // https://github.com/ant-design/ant-design/issues/9793
   it('should not trigger onBlur and onFocus when select item', () => {
     // This function is handled by `rc-select` instead


### PR DESCRIPTION
### Summary

- keep disabled Cascader options inert when they receive a double-click
- apply the existing option/global disabled check before `changeOnSelect` closes the popup
- add an interaction regression test beside the existing enabled double-click case

### Problem

Single-click handling already ignores disabled options, but the separate double-click handler closed the popup whenever `changeOnSelect` was enabled. Double-clicking a disabled option therefore changed popup state even though the option is advertised as unavailable.

### Solution

Reuse `isOptionDisabled(disabled)` in the double-click path. This covers both per-option disabled state and the Cascader-level `disabled` prop while preserving the existing enabled-option behavior.

### Tests

- Before the source change, the new test failed because the popup became closed
- `pnpm test --runInBand` — 11 suites passed, 127 tests passed, 2 skipped, 3 snapshots passed
- `pnpm lint` — 0 errors; 6 pre-existing warnings
- `pnpm compile` — ESM, CJS, and declarations passed
- changed-file Prettier and `git diff --check` — passed

`pnpm tsc` still reports two existing Jest 30 typing errors for the deprecated `toBeCalledWith` matcher alias at unchanged lines 950 and 981; this change adds no such usage and declaration compilation passes.

| Language | Changelog |
| --- | --- |
| English | Keep disabled Cascader options inert when double-clicked. |
| Chinese | 修復停用的 Cascader 選項被雙擊時仍會關閉彈出選單的問題。 |

AI assistance disclosure: Codex was used to trace the interaction path, audit open PRs and issues for overlap, implement the focused guard, and run the validation commands. The failing baseline and passing result were verified against upstream master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复双击禁用选项时弹窗意外关闭的问题。
  * 启用选中即关闭功能时，只有双击可用选项才会关闭弹窗。

* **测试**
  * 新增测试，确保双击禁用选项后弹窗保持打开。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->