### PR TITLE
refactor: use renderable guards for option icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@rc-component/select": "~1.11.0",
     "@rc-component/tree": "~1.5.0",
-    "@rc-component/util": "^1.11.1",
+    "@rc-component/util": "^1.13.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/OptionList/Column.tsx
+++ b/src/OptionList/Column.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import * as React from 'react';
-import { pickAttrs } from '@rc-component/util';
+import { isReactRenderable, pickAttrs } from '@rc-component/util';
 import type { DefaultOptionType, SingleValueType } from '../Cascader';
 import CascaderContext from '../context';
 import { SEARCH_MARK } from '../hooks/useSearchOptions';
@@ -225,10 +225,10 @@ export default function Column<OptionType extends DefaultOptionType = DefaultOpt
               <div className={`${menuItemPrefixCls}-content`}>
                 {optionRender && value !== '__EMPTY__' ? optionRender(option) : label}
               </div>
-              {!isLoading && expandIcon && !isMergedLeaf && (
+              {!isLoading && isReactRenderable(expandIcon) && !isMergedLeaf && (
                 <div className={`${menuItemPrefixCls}-expand-icon`}>{expandIcon}</div>
               )}
-              {isLoading && loadingIcon && (
+              {isLoading && isReactRenderable(loadingIcon) && (
                 <div className={`${menuItemPrefixCls}-loading-icon`}>{loadingIcon}</div>
               )}
             </li>


### PR DESCRIPTION
## 说明

- 使用 `isReactRenderable` 统一判断展开图标和加载图标是否需要渲染
- 支持数字 `0` 等有效 React 内容
- 将 `@rc-component/util` 的最低版本提升到首次提供该 helper 的 `^1.13.0`

## 验证

- `npm run tsc`
- `npm run lint`
- `npm test -- tests/index.spec.tsx --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化级联选项列表中的展开图标和加载图标渲染逻辑。
  - 仅在图标内容可正常显示时渲染对应区域，避免出现空白或异常的图标占位。
  - 改善包含特殊图标配置时的界面显示效果与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->